### PR TITLE
fix: missing return on the promise

### DIFF
--- a/src/services/NodeMonitor.ts
+++ b/src/services/NodeMonitor.ts
@@ -90,7 +90,7 @@ export class NodeMonitor {
 		// Nested fetch node list from current nodeList[]
 		const nodeListPromises = this.nodeList.map(async (node) => {
 			if (isAPIRole(node.roles)) {
-				this.fetchNodesByURL(getNodeURL(node, monitor.API_NODE_PORT));
+				return this.fetchNodesByURL(getNodeURL(node, monitor.API_NODE_PORT));
 			}
 
 			return [];


### PR DESCRIPTION
- The current service was unable to return the full node list.
- To enable getting full nodes from the network, we need to fix this.
- It was missing a return statement on the nested fetch method.
- with this change, the service will be able to fetch node lists from the nested nodes.