### PR TITLE
add web socket status and filter

### DIFF
--- a/openapi/openapi.yml
+++ b/openapi/openapi.yml
@@ -299,11 +299,24 @@ components:
                 hash:
                     type: string
                     example: 7C9BDF478CB18562A078F191867CB9B3FB12601AE0C69606A34C602A0F7D47EB
+        WebSocketStatus:
+            type: object
+            properties:
+                isAvailable:
+                    type: boolean
+                    example: true
+                isWssEnabled:
+                    type: boolean
+                    example: true
+                webSocketUrl:
+                    type: string
+                    example: wss://symbol.node.dev:3001/ws
         ApiStatus:
             type: object
             description: |
                 The status of the api node. Information is from the rest gateway.
             required:
+                - webSocket
                 - restGatewayUrl
                 - isAvailable
                 - lastStatusCheck
@@ -313,6 +326,8 @@ components:
                 - finalization
                 - restVersion
             properties:
+                webSocket:
+                    $ref: '#/components/schemas/WebSocketStatus'
                 restGatewayUrl:
                     type: string
                     description: 'The rest gateway url ready to be connected.'

--- a/openapi/openapi.yml
+++ b/openapi/openapi.yml
@@ -305,10 +305,10 @@ components:
                 isAvailable:
                     type: boolean
                     example: true
-                isWssEnabled:
+                wss:
                     type: boolean
                     example: true
-                webSocketUrl:
+                url:
                     type: string
                     example: wss://symbol.node.dev:3001/ws
         ApiStatus:

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,6 @@
     "requires": true,
     "packages": {
         "": {
-            "name": "symbol-statistics-service",
             "version": "1.1.2",
             "dependencies": {
                 "@types/cors": "^2.8.6",
@@ -29,6 +28,7 @@
                 "@types/mongoose": "^5.7.14",
                 "@types/node": "^14.14.10",
                 "@types/winston": "^2.4.4",
+                "@types/ws": "^8.2.0",
                 "@typescript-eslint/eslint-plugin": "^4.4.0",
                 "@typescript-eslint/parser": "^4.4.0",
                 "eslint": "^7.10.0",
@@ -41,7 +41,8 @@
                 "swagger-cli": "^4.0.4",
                 "ts-node": "^8.10.1",
                 "tslint": "^6.1.2",
-                "typescript": "^3.8.3"
+                "typescript": "^3.8.3",
+                "ws": "^8.2.3"
             }
         },
         "node_modules/@apidevtools/json-schema-ref-parser": {
@@ -580,6 +581,15 @@
             "dev": true,
             "dependencies": {
                 "winston": "*"
+            }
+        },
+        "node_modules/@types/ws": {
+            "version": "8.2.0",
+            "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.2.0.tgz",
+            "integrity": "sha512-cyeefcUCgJlEk+hk2h3N+MqKKsPViQgF5boi9TTHSK+PoR9KWBb/C5ccPcDyAqgsbAYHTwulch725DV84+pSpg==",
+            "dev": true,
+            "dependencies": {
+                "@types/node": "*"
             }
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
@@ -5423,6 +5433,26 @@
             "resolved": "https://registry.npmjs.org/utf8/-/utf8-2.1.2.tgz",
             "integrity": "sha1-H6DZJw6b6FDZsFAn9jUZv0ZFfZY="
         },
+        "node_modules/symbol-sdk/node_modules/ws": {
+            "version": "7.5.5",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.5.tgz",
+            "integrity": "sha512-BAkMFcAzl8as1G/hArkxOxq3G7pjUqQ3gzYbLL0/5zNkph70e+lCoxBGnm6AW1+/aiNeV4fnKqZ8m4GZewmH2w==",
+            "engines": {
+                "node": ">=8.3.0"
+            },
+            "peerDependencies": {
+                "bufferutil": "^4.0.1",
+                "utf-8-validate": "^5.0.2"
+            },
+            "peerDependenciesMeta": {
+                "bufferutil": {
+                    "optional": true
+                },
+                "utf-8-validate": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/table": {
             "version": "6.0.7",
             "resolved": "https://registry.npmjs.org/table/-/table-6.0.7.tgz",
@@ -6115,11 +6145,12 @@
             }
         },
         "node_modules/ws": {
-            "version": "7.5.5",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.5.tgz",
-            "integrity": "sha512-BAkMFcAzl8as1G/hArkxOxq3G7pjUqQ3gzYbLL0/5zNkph70e+lCoxBGnm6AW1+/aiNeV4fnKqZ8m4GZewmH2w==",
+            "version": "8.2.3",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.2.3.tgz",
+            "integrity": "sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA==",
+            "dev": true,
             "engines": {
-                "node": ">=8.3.0"
+                "node": ">=10.0.0"
             },
             "peerDependencies": {
                 "bufferutil": "^4.0.1",
@@ -6711,6 +6742,15 @@
             "dev": true,
             "requires": {
                 "winston": "*"
+            }
+        },
+        "@types/ws": {
+            "version": "8.2.0",
+            "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.2.0.tgz",
+            "integrity": "sha512-cyeefcUCgJlEk+hk2h3N+MqKKsPViQgF5boi9TTHSK+PoR9KWBb/C5ccPcDyAqgsbAYHTwulch725DV84+pSpg==",
+            "dev": true,
+            "requires": {
+                "@types/node": "*"
             }
         },
         "@typescript-eslint/eslint-plugin": {
@@ -10389,6 +10429,12 @@
                     "version": "2.1.2",
                     "resolved": "https://registry.npmjs.org/utf8/-/utf8-2.1.2.tgz",
                     "integrity": "sha1-H6DZJw6b6FDZsFAn9jUZv0ZFfZY="
+                },
+                "ws": {
+                    "version": "7.5.5",
+                    "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.5.tgz",
+                    "integrity": "sha512-BAkMFcAzl8as1G/hArkxOxq3G7pjUqQ3gzYbLL0/5zNkph70e+lCoxBGnm6AW1+/aiNeV4fnKqZ8m4GZewmH2w==",
+                    "requires": {}
                 }
             }
         },
@@ -10939,9 +10985,10 @@
             }
         },
         "ws": {
-            "version": "7.5.5",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.5.tgz",
-            "integrity": "sha512-BAkMFcAzl8as1G/hArkxOxq3G7pjUqQ3gzYbLL0/5zNkph70e+lCoxBGnm6AW1+/aiNeV4fnKqZ8m4GZewmH2w==",
+            "version": "8.2.3",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.2.3.tgz",
+            "integrity": "sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA==",
+            "dev": true,
             "requires": {}
         },
         "xdg-basedir": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
         "@types/mongoose": "^5.7.14",
         "@types/node": "^14.14.10",
         "@types/winston": "^2.4.4",
+        "@types/ws": "^8.2.0",
         "@typescript-eslint/eslint-plugin": "^4.4.0",
         "@typescript-eslint/parser": "^4.4.0",
         "eslint": "^7.10.0",
@@ -36,7 +37,8 @@
         "swagger-cli": "^4.0.4",
         "ts-node": "^8.10.1",
         "tslint": "^6.1.2",
-        "typescript": "^3.8.3"
+        "typescript": "^3.8.3",
+        "ws": "^8.2.3"
     },
     "dependencies": {
         "@types/cors": "^2.8.6",

--- a/src/models/Node.ts
+++ b/src/models/Node.ts
@@ -122,6 +122,7 @@ const NodeSchema: Schema = new Schema({
 		nodePublicKey: {
 			type: String,
 			required: false,
+			index: true,
 		},
 		restVersion: {
 			type: String,
@@ -137,6 +138,7 @@ const NodeSchema: Schema = new Schema({
 		type: String,
 		required: true,
 		unique: true,
+		index: true,
 	},
 	roles: {
 		type: Number,

--- a/src/models/Node.ts
+++ b/src/models/Node.ts
@@ -52,6 +52,23 @@ const NodeSchema: Schema = new Schema({
 		},
 	},
 	apiStatus: {
+		webSocket: {
+			type: {
+				isAvailable: {
+					type: Boolean,
+					required: false,
+				},
+				isWssEnabled: {
+					type: Boolean,
+					required: false,
+				},
+				webSocketUrl: {
+					type: String,
+					required: false,
+				},
+			},
+			required: false,
+		},
 		restGatewayUrl: {
 			type: String,
 			required: false,

--- a/src/models/Node.ts
+++ b/src/models/Node.ts
@@ -58,11 +58,11 @@ const NodeSchema: Schema = new Schema({
 					type: Boolean,
 					required: false,
 				},
-				isWssEnabled: {
+				wss: {
 					type: Boolean,
 					required: false,
 				},
-				webSocketUrl: {
+				url: {
 					type: String,
 					required: false,
 				},

--- a/src/models/Node.ts
+++ b/src/models/Node.ts
@@ -212,6 +212,20 @@ const NodeSchema: Schema = new Schema({
 	},
 });
 
+NodeSchema.index(
+	{ 'apiStatus.isAvailable': 1, 'apiStatus.nodeStatus.apiNode': 1, 'apiStatus.nodeStatus.db': 1 },
+	{
+		name: 'inx_suggestedNode',
+	},
+);
+
+NodeSchema.index(
+	{ 'apiStatus.isHttpsEnabled': 1, 'apiStatus.webSocket.wss': 1, 'apiStatus.webSocket.isAvailable': 1 },
+	{
+		name: 'inx_sslNode',
+	},
+);
+
 NodeSchema.set('toObject', {
 	transform: (doc: Document, ret: Document) => {
 		delete ret._id;

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -26,6 +26,8 @@ export class Routes {
 
 				Object.assign(searchCriteria.filter, {
 					'apiStatus.isHttpsEnabled': isSSL,
+					'apiStatus.webSocket.isWssEnabled': isSSL,
+					'apiStatus.webSocket.isAvailable': true,
 				});
 			}
 

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -26,7 +26,7 @@ export class Routes {
 
 				Object.assign(searchCriteria.filter, {
 					'apiStatus.isHttpsEnabled': isSSL,
-					'apiStatus.webSocket.isWssEnabled': isSSL,
+					'apiStatus.webSocket.wss': isSSL,
 					'apiStatus.webSocket.isAvailable': true,
 				});
 			}

--- a/src/services/ApiNodeService.ts
+++ b/src/services/ApiNodeService.ts
@@ -240,6 +240,7 @@ export class ApiNodeService {
 			webSocketUrl = `wss://${host}:3001/ws`;
 		} else {
 			const wsHealth = await ApiNodeService.checkWebSocketHealth(host, 3000, 'ws:');
+
 			webSocketUrl = wsHealth ? `ws://${host}:3000/ws` : undefined;
 		}
 

--- a/src/services/ApiNodeService.ts
+++ b/src/services/ApiNodeService.ts
@@ -2,6 +2,7 @@ import { HTTP } from '@src/services/Http';
 import * as winston from 'winston';
 import { basename } from '@src/utils';
 import { Logger } from '@src/infrastructure';
+import { WebSocket } from 'ws';
 
 const logger: winston.Logger = Logger.getLogger(basename(__filename));
 
@@ -174,5 +175,29 @@ export class ApiNodeService {
 		} catch (e) {
 			return false;
 		}
+	};
+
+	/**
+	 * Get the heartbeat of the web socket connection
+	 * @param host - host domain
+	 * @param port - websocket port
+	 * @param protocol - websocket protocal wss or ws
+	 * @returns boolean
+	 */
+	static webSocketHeartbeat = async (host: string, port: number, protocol: string): Promise<boolean> => {
+		return new Promise((resolve, reject) => {
+			const clientWS = new WebSocket(`${protocol}//${host}:${port}/ws`, {
+				timeout: 1000,
+			});
+
+			clientWS.on('open', () => {
+				resolve(true);
+			});
+
+			clientWS.on('error', (e) => {
+				logger.error(`Fail to request web socket heartbeat: ${protocol}//${host}:${port}/ws`, e);
+				resolve(false);
+			});
+		});
 	};
 }


### PR DESCRIPTION
Some of the nodes are not supported `wss` WebSocket, it cause some issue in the web application.

- Add WebSocket status
- Add filter criteria on the node list, when `ssl=true`, it will filter HTTPS node with `wss` WebSocket.

Example:
![Screenshot 2021-11-16 at 1 50 07 AM](https://user-images.githubusercontent.com/5649156/141833931-f381fe76-eeb6-4e54-9f3e-84d88eba5148.png)
![Screenshot 2021-11-16 at 1 48 58 AM](https://user-images.githubusercontent.com/5649156/141833938-081b9b8a-c981-41bf-ba07-1ef34ca21c04.png)
![Screenshot 2021-11-16 at 2 19 50 AM](https://user-images.githubusercontent.com/5649156/141833941-2ae4a4fe-4e06-4e79-85f9-71a92c8701eb.png)

