### PR TITLE
Remove default filter

### DIFF
--- a/src/models/Node.ts
+++ b/src/models/Node.ts
@@ -13,6 +13,7 @@ export interface INode {
 	publicKey: string;
 	roles: number;
 	version: number;
+	nodePublicKey?: string;
 	peerStatus?: PeerStatus;
 	apiStatus?: ApiStatus;
 	hostDetail?: IHostDetail;
@@ -119,11 +120,6 @@ const NodeSchema: Schema = new Schema({
 			},
 			required: false,
 		},
-		nodePublicKey: {
-			type: String,
-			required: false,
-			index: true,
-		},
 		restVersion: {
 			type: String,
 			required: false,
@@ -147,6 +143,11 @@ const NodeSchema: Schema = new Schema({
 	version: {
 		type: Number,
 		required: true,
+	},
+	nodePublicKey: {
+		type: String,
+		required: false,
+		index: true,
 	},
 	hostDetail: {
 		type: {

--- a/src/models/Node.ts
+++ b/src/models/Node.ts
@@ -13,7 +13,6 @@ export interface INode {
 	publicKey: string;
 	roles: number;
 	version: number;
-	nodePublicKey?: string;
 	peerStatus?: PeerStatus;
 	apiStatus?: ApiStatus;
 	hostDetail?: IHostDetail;
@@ -120,6 +119,11 @@ const NodeSchema: Schema = new Schema({
 			},
 			required: false,
 		},
+		nodePublicKey: {
+			type: String,
+			required: false,
+			index: true,
+		},
 		restVersion: {
 			type: String,
 			required: false,
@@ -143,11 +147,6 @@ const NodeSchema: Schema = new Schema({
 	version: {
 		type: Number,
 		required: true,
-	},
-	nodePublicKey: {
-		type: String,
-		required: false,
-		index: true,
 	},
 	hostDetail: {
 		type: {

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -14,9 +14,7 @@ export class Routes {
 			const { filter, limit, ssl } = req.query;
 
 			let searchCriteria: NodeSearchCriteria = {
-				filter: {
-					version: { $gte: symbol.MIN_PARTNER_NODE_VERSION },
-				},
+				filter: {},
 				limit: Number(limit) || 0,
 			};
 
@@ -28,6 +26,7 @@ export class Routes {
 					'apiStatus.isHttpsEnabled': isSSL,
 					'apiStatus.webSocket.wss': isSSL,
 					'apiStatus.webSocket.isAvailable': true,
+					version: { $gte: symbol.MIN_PARTNER_NODE_VERSION },
 				});
 			}
 
@@ -44,6 +43,7 @@ export class Routes {
 					'apiStatus.isAvailable': true,
 					'apiStatus.nodeStatus.apiNode': 'up',
 					'apiStatus.nodeStatus.db': 'up',
+					version: { $gte: symbol.MIN_PARTNER_NODE_VERSION },
 				});
 			}
 
@@ -54,6 +54,7 @@ export class Routes {
 					'apiStatus.isAvailable': true,
 					'apiStatus.nodeStatus.apiNode': 'up',
 					'apiStatus.nodeStatus.db': 'up',
+					version: { $gte: symbol.MIN_PARTNER_NODE_VERSION },
 				});
 			}
 

--- a/src/services/ApiNodeService.ts
+++ b/src/services/ApiNodeService.ts
@@ -262,4 +262,17 @@ export class ApiNodeService {
 			url: webSocketUrl,
 		};
 	};
+
+	/**
+	 * Check on protocol (https / http), and build url from hostname.
+	 * @param hostname example: symbol.com
+	 * @returns string example: https://symbol.com:3001
+	 */
+	static buildHostUrl = async (hostname: string): Promise<string> => {
+		const isHttps = await ApiNodeService.isHttpsEnabled(hostname);
+		const protocol = isHttps ? 'https:' : 'http:';
+		const port = isHttps ? 3001 : 3000;
+
+		return `${protocol}//${hostname}:${port}`;
+	};
 }

--- a/src/services/ApiNodeService.ts
+++ b/src/services/ApiNodeService.ts
@@ -32,6 +32,7 @@ export interface ApiStatus {
 	nodeStatus?: NodeStatus;
 	chainHeight?: number;
 	finalization?: FinalizedBlock;
+	nodePublicKey?: string;
 	restVersion?: string;
 	lastStatusCheck: number;
 }
@@ -97,10 +98,17 @@ export class ApiNodeService {
 				return apiStatus;
 			}
 
-			const [nodeServer, nodeHealth] = await Promise.all([
+			const [nodeInfo, nodeServer, nodeHealth] = await Promise.all([
+				ApiNodeService.getNodeInfo(hostUrl),
 				ApiNodeService.getNodeServer(hostUrl),
 				ApiNodeService.getNodeHealth(hostUrl),
 			]);
+
+			if (nodeInfo) {
+				Object.assign(apiStatus, {
+					nodePublicKey: nodeInfo.nodePublicKey,
+				});
+			}
 
 			if (chainInfo) {
 				Object.assign(apiStatus, {

--- a/src/services/ApiNodeService.ts
+++ b/src/services/ApiNodeService.ts
@@ -72,16 +72,14 @@ export interface ServerInfo {
 }
 
 export class ApiNodeService {
-	static getStatus = async (host: string): Promise<ApiStatus> => {
+	static getStatus = async (hostUrl: string): Promise<ApiStatus> => {
 		try {
-			const isHttps = await ApiNodeService.isHttpsEnabled(host);
-			const protocol = isHttps ? 'https:' : 'http:';
-			const port = isHttps ? 3001 : 3000;
+			const { protocol, hostname } = new URL(hostUrl);
 
-			logger.info(`Getting node status for: ${protocol}//${host}:${port}`);
+			logger.info(`Getting node status for: ${hostUrl}`);
 
 			let apiStatus: ApiStatus = {
-				restGatewayUrl: `${protocol}//${host}:${port}`,
+				restGatewayUrl: `${hostUrl}`,
 				isAvailable: false,
 				lastStatusCheck: Date.now(),
 				webSocket: {
@@ -146,9 +144,9 @@ export class ApiNodeService {
 
 			return apiStatus;
 		} catch (e) {
-			logger.error(`Fail to request host node status: ${host}`, e);
+			logger.error(`Fail to request host node status: ${hostUrl}`, e);
 			return {
-				restGatewayUrl: `http://${host}:3000`,
+				restGatewayUrl: `${hostUrl}`,
 				webSocket: {
 					isAvailable: false,
 					wss: false,
@@ -160,42 +158,42 @@ export class ApiNodeService {
 		}
 	};
 
-	static getNodeInfo = async (host: string, port: number, protocol: string): Promise<NodeInfo | null> => {
+	static getNodeInfo = async (hostUrl: string): Promise<NodeInfo | null> => {
 		try {
-			return (await HTTP.get(`${protocol}//${host}:${port}/node/info`)).data;
+			return (await HTTP.get(`${hostUrl}/node/info`)).data;
 		} catch (e) {
-			logger.error(`Fail to request /node/info: ${host}`, e);
+			logger.error(`Fail to request /node/info: ${hostUrl}`, e);
 			return null;
 		}
 	};
 
-	static getNodeChainInfo = async (host: string, port: number, protocol: string): Promise<ChainInfo | null> => {
+	static getNodeChainInfo = async (hostUrl: string): Promise<ChainInfo | null> => {
 		try {
-			return (await HTTP.get(`${protocol}//${host}:${port}/chain/info`)).data;
+			return (await HTTP.get(`${hostUrl}/chain/info`)).data;
 		} catch (e) {
-			logger.error(`Fail to request /chain/info: ${host}`, e);
+			logger.error(`Fail to request /chain/info: ${hostUrl}`, e);
 			return null;
 		}
 	};
 
-	static getNodeServer = async (host: string, port: number, protocol: string): Promise<ServerInfo | null> => {
+	static getNodeServer = async (hostUrl: string): Promise<ServerInfo | null> => {
 		try {
-			const nodeServerInfo = (await HTTP.get(`${protocol}//${host}:${port}/node/server`)).data;
+			const nodeServerInfo = (await HTTP.get(`${hostUrl}/node/server`)).data;
 
 			return nodeServerInfo.serverInfo;
 		} catch (e) {
-			logger.error(`Fail to request /node/server: ${host}`, e);
+			logger.error(`Fail to request /node/server: ${hostUrl}`, e);
 			return null;
 		}
 	};
 
-	static getNodeHealth = async (host: string, port: number, protocol: string): Promise<NodeStatus | null> => {
+	static getNodeHealth = async (hostUrl: string): Promise<NodeStatus | null> => {
 		try {
-			const health = (await HTTP.get(`${protocol}//${host}:${port}/node/health`)).data;
+			const health = (await HTTP.get(`${hostUrl}/node/health`)).data;
 
 			return health.status;
 		} catch (e) {
-			logger.error(`Fail to request /node/health: ${host}`, e);
+			logger.error(`Fail to request /node/health: ${hostUrl}`, e);
 			return null;
 		}
 	};

--- a/src/services/ApiNodeService.ts
+++ b/src/services/ApiNodeService.ts
@@ -109,7 +109,6 @@ export class ApiNodeService {
 					isAvailable: true,
 					isHttpsEnabled: isHttps,
 					nodePublicKey: nodeInfo.nodePublicKey,
-					version: nodeInfo.version,
 				});
 			}
 

--- a/src/services/ApiNodeService.ts
+++ b/src/services/ApiNodeService.ts
@@ -234,24 +234,24 @@ export class ApiNodeService {
 
 	/**
 	 * Get the status of the web socket connection
-	 * @param host - host domain
+	 * @param hostname - host domain
 	 * @param isHttp - ssl enable flag
 	 * @returns WebSocketStatus
 	 */
-	static webSocketStatus = async (host: string, isHttp?: boolean): Promise<WebSocketStatus> => {
+	static webSocketStatus = async (hostname: string, isHttp?: boolean): Promise<WebSocketStatus> => {
 		let webSocketUrl = undefined;
 		let wssHealth = false;
 
 		if (isHttp) {
-			wssHealth = await ApiNodeService.checkWebSocketHealth(host, 3001, 'wss:');
+			wssHealth = await ApiNodeService.checkWebSocketHealth(hostname, 3001, 'wss:');
 		}
 
 		if (wssHealth) {
-			webSocketUrl = `wss://${host}:3001/ws`;
+			webSocketUrl = `wss://${hostname}:3001/ws`;
 		} else {
-			const wsHealth = await ApiNodeService.checkWebSocketHealth(host, 3000, 'ws:');
+			const wsHealth = await ApiNodeService.checkWebSocketHealth(hostname, 3000, 'ws:');
 
-			webSocketUrl = wsHealth ? `ws://${host}:3000/ws` : undefined;
+			webSocketUrl = wsHealth ? `ws://${hostname}:3000/ws` : undefined;
 		}
 
 		return {

--- a/src/services/ChainHeightMonitor.ts
+++ b/src/services/ChainHeightMonitor.ts
@@ -64,7 +64,8 @@ export class ChainHeightMonitor {
 			logger.error('Failed to get node list. Use nodes from config');
 			for (const node of symbol.NODES) {
 				const url = new URL(node);
-				const nodeInfo = await ApiNodeService.getNodeInfo(url.host, Number(url.port), url.protocol);
+				const hostUrl = await ApiNodeService.buildHostUrl(url.hostname);
+				const nodeInfo = await ApiNodeService.getNodeInfo(hostUrl);
 
 				if (nodeInfo) {
 					const status = await ApiNodeService.getStatus(nodeInfo.host);
@@ -85,7 +86,9 @@ export class ChainHeightMonitor {
 			const protocol = isHttps ? 'https:' : 'http:';
 			const port = isHttps ? 3001 : 3000;
 
-			return ApiNodeService.getNodeChainInfo(node.host, port, protocol);
+			const hostUrl = `${protocol}//${node.host}:${port}`;
+
+			return ApiNodeService.getNodeChainInfo(hostUrl);
 		});
 		const nodeChainInfoList = await Promise.all(nodeChainInfoPromises);
 

--- a/src/services/GeolocationMonitor.ts
+++ b/src/services/GeolocationMonitor.ts
@@ -61,7 +61,8 @@ export class GeolocationMonitor {
 		} catch (e) {
 			for (const node of symbol.NODES) {
 				const url = new URL(node);
-				const nodeInfo = await ApiNodeService.getNodeInfo(url.host, Number(url.port), url.protocol);
+				const hostUrl = await ApiNodeService.buildHostUrl(url.hostname);
+				const nodeInfo = await ApiNodeService.getNodeInfo(hostUrl);
 
 				if (nodeInfo) {
 					const status = await ApiNodeService.getStatus(nodeInfo.host);

--- a/src/services/NodeMonitor.ts
+++ b/src/services/NodeMonitor.ts
@@ -167,13 +167,15 @@ export class NodeMonitor {
 
 			if (isAPIRole(node.roles)) {
 				const hostUrl = await ApiNodeService.buildHostUrl(node.host);
-				const nodeStatus = await ApiNodeService.getNodeInfo(hostUrl);
+				// To fix version 0 issue return from `/node/peers`
 
-				if (nodeStatus) {
-					nodeWithInfo.version = nodeStatus.version;
-					nodeWithInfo.nodePublicKey = nodeStatus.nodePublicKey;
+				if (node.version === 0) {
+					const nodeStatus = await ApiNodeService.getNodeInfo(hostUrl);
+
+					if (nodeStatus) {
+						nodeWithInfo.version = nodeStatus.version;
+					}
 				}
-
 				nodeWithInfo.apiStatus = await ApiNodeService.getStatus(hostUrl);
 			}
 		} catch (e) {

--- a/src/services/NodeMonitor.ts
+++ b/src/services/NodeMonitor.ts
@@ -166,7 +166,15 @@ export class NodeMonitor {
 			}
 
 			if (isAPIRole(node.roles)) {
-				nodeWithInfo.apiStatus = await ApiNodeService.getStatus(node.host);
+				const hostUrl = await ApiNodeService.buildHostUrl(node.host);
+				const nodeStatus = await ApiNodeService.getNodeInfo(hostUrl);
+
+				if (nodeStatus) {
+					nodeWithInfo.version = nodeStatus.version;
+					nodeWithInfo.nodePublicKey = nodeStatus.nodePublicKey;
+				}
+
+				nodeWithInfo.apiStatus = await ApiNodeService.getStatus(hostUrl);
 			}
 		} catch (e) {
 			logger.error(`GetNodeInfo. Failed to fetch info for "${node}". ${e.message}`);
@@ -216,8 +224,9 @@ export class NodeMonitor {
 	private getNetworkType = async (): Promise<void> => {
 		for (const nodeUrl of symbol.NODES) {
 			const url = new URL(nodeUrl);
+			const hostUrl = await ApiNodeService.buildHostUrl(url.hostname);
 
-			const nodeInfo = await ApiNodeService.getNodeInfo(url.hostname, Number(url.port), url.protocol);
+			const nodeInfo = await ApiNodeService.getNodeInfo(hostUrl);
 
 			if (nodeInfo) {
 				this.networkIdentifier = nodeInfo.networkIdentifier;


### PR DESCRIPTION
### ~~Breaking change~~
- ~~moved properties `apiStatus.nodePublicKey` -> `nodePublicKey`~~

### Fix
- Removed the default `version` search criteria, so we can get exactly the full nodes in `/nodes` endpoint
- Attached`version` search criteria in the `ssl` and `?filter=preferred | ?filter=suggested`, because we want users to always get the latest version of the node.
- Refactor `ApiNodeService`, first check on the `chain/info` endpoint, if it's not working, we can skip all.
- Resolved Node version 0 problem, we should request `node/info` for every node.

### Add
-  add `buildHostUrl` method, it build URL base on SSL status (https/http)