### PR TITLE
feat: add node version stats

### DIFF
--- a/openapi/openapi.yml
+++ b/openapi/openapi.yml
@@ -236,14 +236,21 @@ components:
             additionalProperties: true
             # Note, we could have a large number of possible role types once IPv6 and IPv4 are introduced
             description: The number of nodes indexed by role type.
+        NodeStatsNodeVersion:
+            type: object
+            additionalProperties: true
+            description: The number of nodes indexed by version.
         NodeStats:
             description: The summary of the number of nodes per role type.
             type: object
             required:
                 - nodeTypes
+                - nodeVersion
             properties:
                 nodeTypes:
                     $ref: '#/components/schemas/NodeStatsNodeTypes'
+                nodeVersion:
+                    $ref: '#/components/schemas/NodeStatsNodeVersion'
         NodeListLimit:
             type: integer
             example: 30

--- a/src/models/NodesStats.ts
+++ b/src/models/NodesStats.ts
@@ -5,12 +5,19 @@ export interface INodesStats {
 	nodeTypes: {
 		[key: string]: number;
 	};
+	nodeVersion: {
+		[key: string]: number;
+	};
 }
 
 export interface NodesStatsDocument extends INodesStats, Document {}
 
 const NodesStatsSchema: Schema = new Schema({
 	nodeTypes: {
+		type: Schema.Types.Mixed,
+		required: false,
+	},
+	nodeVersion: {
 		type: Schema.Types.Mixed,
 		required: false,
 	},

--- a/src/services/NodesStats.ts
+++ b/src/services/NodesStats.ts
@@ -6,17 +6,22 @@ export class NodesStats implements INodesStats {
 		[key: string]: number;
 	};
 
+	nodeVersion!: {
+		[key: string]: number;
+	};
+
 	constructor() {
 		this.clear();
 	}
 
-	private updateStats(nodeType: string) {
-		if (this.nodeTypes[nodeType] === undefined) this.nodeTypes[nodeType] = 1;
-		else this.nodeTypes[nodeType]++;
+	private updateStats(data: Record<string, number>, key: string) {
+		if (data[key] === undefined) data[key] = 1;
+		else data[key]++;
 	}
 
 	addToStats(node: INode) {
-		this.updateStats(String(node.roles));
+		this.updateStats(this.nodeTypes, String(node.roles));
+		this.updateStats(this.nodeVersion, String(node.version));
 	}
 
 	getTotal() {
@@ -37,5 +42,6 @@ export class NodesStats implements INodesStats {
 			'6': 0,
 			'7': 0,
 		};
+		this.nodeVersion = {};
 	}
 }


### PR DESCRIPTION
- Add node version stat data on NodesStats.
- I add `data` params on `updateStats` method, I believe we can share this method, and use it for a different set of stats data for node.