### PR TITLE
feat: node list ordering[random, natural] added

### DIFF
--- a/openapi/openapi.yml
+++ b/openapi/openapi.yml
@@ -38,6 +38,13 @@ paths:
                   example: true
                   schema:
                       $ref: '#/components/schemas/NodeListSSL'
+                - name: order
+                  in: query
+                  required: false
+                  description: Sorts and samples the nodes to be returned
+                  example: random
+                  schema:
+                      $ref: '#/components/schemas/NodeListOrder'
             responses:
                 200:
                     description: The list of known nodes.
@@ -256,6 +263,15 @@ components:
                 - 'suggested'
                 - 'preferred'
             example: 'preferred'
+        NodeListOrder:
+            type: string
+            description: |
+                'natural': Nodes are returned in the order they are stored in the database.
+                `random`: Default list order when a limit is specified. Returns {limit} number of random nodes, ordering falls back to 'natural' when limit is not specified.
+            enum:
+                - 'natural'
+                - 'random'
+            example: 'random'
         NodeListSSL:
             description: When true, return only nodes which support HTTPS.
             type: boolean

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -1,5 +1,5 @@
 import { Express, Request, Response } from 'express';
-import { DataBase, NodeSearchCriteria } from '@src/services/DataBase';
+import { DataBase, NodeSearchCriteria, NodeListOrder } from '@src/services/DataBase';
 import { NotFoundError, InternalServerError, UnsupportedFilterError } from '@src/infrastructure/Error';
 import { symbol } from '@src/config';
 
@@ -11,13 +11,14 @@ enum NodeFilter {
 export class Routes {
 	static register = async (app: Express) => {
 		app.get('/nodes', async (req: Request, res: Response) => {
-			const { filter, limit, ssl } = req.query;
+			const { filter, limit, ssl, order } = req.query;
 
 			let searchCriteria: NodeSearchCriteria = {
 				filter: {
 					version: { $gte: symbol.MIN_PARTNER_NODE_VERSION },
 				},
 				limit: Number(limit) || 0,
+				order: order ? ((order as string).toLowerCase() as NodeListOrder) : NodeListOrder.Random,
 			};
 
 			// add ssl filter to query isHttpsEnabled nodes.

--- a/src/services/DataBase.ts
+++ b/src/services/DataBase.ts
@@ -12,9 +12,14 @@ import { SearchCriteria, Pagination, PaginationResponse } from '@src/infrastruct
 
 const logger: winston.Logger = Logger.getLogger(basename(__filename));
 
+export enum NodeListOrder {
+	Natural = 'natural',
+	Random = 'random',
+}
 export interface NodeSearchCriteria {
 	filter: object;
 	limit: number;
+	order: NodeListOrder;
 }
 
 export class DataBase {
@@ -28,7 +33,13 @@ export class DataBase {
 		logger.info(`DataBase Connected to MongoDB`);
 	};
 
-	static getNodeList = ({ filter, limit }: NodeSearchCriteria = { filter: {}, limit: 0 }): Promise<NodeDocument[]> => {
+	static getNodeList = (
+		{ filter, limit, order }: NodeSearchCriteria = { filter: {}, limit: 0, order: NodeListOrder.Random },
+	): Promise<NodeDocument[]> => {
+		if (limit > 0 && order === NodeListOrder.Random) {
+			return Node.aggregate([{ $match: { ...filter } }, { $sample: { size: limit } }]).exec();
+		}
+
 		// prettier-ignore
 		return Node
 			.find(filter)


### PR DESCRIPTION
default order is random when the limit parameter is specified otherwise falls back to natural.

partly fixes https://github.com/symbol/statistics-service/issues/103
