### PR TITLE
fix: tsconfig.build.json added to exclude tests from build but keep for tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "scripts": {
         "dev": "nodemon",
         "debug": "node --inspect-brk=0.0.0.0:9229 --require ts-node/register src/app.ts",
-        "build": "shx rm -rf ./dist/ && tsc && shx cp -r openapi dist/openapi",
+        "build": "shx rm -rf ./dist/ && tsc -p tsconfig.build.json && shx cp -r openapi dist/openapi",
         "build:clients": "bash scripts/build-clients.sh",
         "start": "node dist/app.js",
         "version": "echo $npm_package_version",

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,31 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "strict": true,
+        "baseUrl": "./",
+        "outDir": "dist",
+        "removeComments": true,
+        "experimentalDecorators": true,
+        "target": "es6",
+        "emitDecoratorMetadata": true,
+        "moduleResolution": "node",
+        "resolveJsonModule": true,
+        "importHelpers": true,
+        "types": [
+            "node",
+            "mocha"
+        ],
+        "typeRoots": [
+            "node_modules/@types"
+        ],
+        "paths": {
+            "@src/*": [ "src/*" ]
+        }
+    },
+    "include": [
+        "./src/**/*.ts",
+    ],
+    "exclude": [
+        "./src/public/"
+    ]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,32 +1,6 @@
 {
-    "compilerOptions": {
-        "module": "commonjs",
-        "strict": true,
-        "baseUrl": "./",
-        "outDir": "dist",
-        "removeComments": true,
-        "experimentalDecorators": true,
-        "target": "es6",
-        "emitDecoratorMetadata": true,
-        "moduleResolution": "node",
-        "resolveJsonModule": true,
-        "importHelpers": true,
-        "types": [
-            "node",
-            "mocha"
-        ],
-        "typeRoots": [
-            "node_modules/@types"
-        ],
-        "paths": {
-            "@src/*": [ "src/*" ]
-        }
-    },
+    "extends": "./tsconfig.build.json",
     "include": [
-        "./src/**/*.ts",
-        "./test/**/*.test.ts"
+        "./test/**/*.test.ts",
     ],
-    "exclude": [
-        "./src/public/"
-    ]
 }


### PR DESCRIPTION
### What was the issue?
Since we started to run unit tests, it's started to create the `test` folder under the `dist` and thus the docker container started to fail at finding the `app.js` in the root(it started to appear as `src/app.js`.
### The fix
Created a different `tsconfig` file for `build` use which doesn't include the test folder and files.



