### PR TITLE
fix: stale nodes lastAvailable field update issue fixed

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -102,3 +102,13 @@ export const runTaskInChunks = async <T>(
 		numOfNodesProcessed += chunk.length;
 	}
 };
+
+export const splitByPredicate = <T>(predicate: (item: T) => boolean, arr: T[]): { filtered: T[]; unfiltered: T[] } => {
+	return arr.reduce(
+		(res, item: T) => {
+			res[predicate(item) ? 'filtered' : 'unfiltered'].push(item);
+			return res;
+		},
+		{ filtered: [] as T[], unfiltered: [] as T[] },
+	);
+};


### PR DESCRIPTION
### What was the issue?
`lastAvailable` field was not retained consistently, was being set for unavailable nodes occasionally.

### What's the fix?
- Clear distinction between stale nodes and soon to be stale nodes. (nodesStored = `availableNodes` + `soonToBeStaleNodes`)
- Preserve the `lastAvailable` field in the node read from DB
- Reorder node fetching logic: reading nodes from DB goes first