### PR TITLE
[statistics-service] fix: node monitoring scheduled job hanging issue fixed

### DIFF
--- a/src/infrastructure/Logger.ts
+++ b/src/infrastructure/Logger.ts
@@ -11,10 +11,10 @@ export class Logger {
 		filename: 'error.log',
 	});
 
-	static getLogger(name: string): winston.Logger {
+	static getLogger(name: string, fileTransport = true): winston.Logger {
 		return winston.createLogger({
 			format: winston.format.combine(winston.format.label({ label: name })),
-			transports: [Logger.transportsConsole, Logger.transportsFile],
+			transports: [Logger.transportsConsole, ...(fileTransport ? [Logger.transportsFile] : [])],
 		});
 	}
 

--- a/src/services/Http.ts
+++ b/src/services/Http.ts
@@ -1,17 +1,17 @@
 import axios, { AxiosResponse, AxiosRequestConfig } from 'axios';
 import { monitor } from '@src/config';
 
-const REQEST_TIMEOUT = monitor.REQUEST_TIMEOUT;
-
 export class HTTP {
+	static TIMEOUT_MSG = `HTTP get request failed. Timeout error`;
 	static get(url: string, config?: AxiosRequestConfig | undefined): Promise<AxiosResponse<any>> {
 		return new Promise<AxiosResponse<any>>((resolve, reject) => {
+			const options = { timeout: monitor.REQUEST_TIMEOUT, ...config };
 			const timeout = setTimeout(() => {
-				reject(Error(`HTTP get request failed. Timeout error`));
-			}, REQEST_TIMEOUT + REQEST_TIMEOUT * 0.1);
+				reject(Error(HTTP.TIMEOUT_MSG));
+			}, options.timeout * 1.1);
 
 			axios
-				.get(url, { timeout: REQEST_TIMEOUT, ...config })
+				.get(url, options)
 				.then((response) => {
 					clearTimeout(timeout);
 					resolve(response);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -112,3 +112,22 @@ export const splitByPredicate = <T>(predicate: (item: T) => boolean, arr: T[]): 
 		{ filtered: [] as T[], unfiltered: [] as T[] },
 	);
 };
+
+const promiseTimeout = (ms: number, timeoutVal: any, logger: winston.Logger, loggingMethod: string) => {
+	return new Promise((resolve) =>
+		setTimeout(() => {
+			logger.info(`[${loggingMethod}] Promise timeout reached, returning ${timeoutVal}`);
+			resolve(timeoutVal);
+		}, ms),
+	);
+};
+
+export const promiseAllTimeout = (
+	promises: Promise<any>[],
+	timeout: number,
+	logger: winston.Logger,
+	loggingMethod: string,
+	timeOutVal?: any,
+): Promise<any> => {
+	return Promise.all(promises.map((promise) => Promise.race([promise, promiseTimeout(timeout, timeOutVal, logger, loggingMethod)])));
+};

--- a/test/ApiNodeService.test.ts
+++ b/test/ApiNodeService.test.ts
@@ -1,0 +1,54 @@
+import { expect } from 'chai';
+import { stub } from 'sinon';
+import { ApiNodeService } from '@src/services/ApiNodeService';
+
+describe('ApiNodeService', () => {
+	it('getStatus proceeds even some of the api calls hangs', async () => {
+		// Arrange:
+		const webSocketStatus = { isAvailable: false, wss: false, url: undefined };
+		const serverInfo = {
+			restVersion: '2.4.0',
+			sdkVersion: '2.4.1',
+			deployment: {
+				deploymentTool: 'symbol-bootstrap',
+				deploymentToolVersion: '1.1.6',
+				lastUpdatedDate: '2022-03-16',
+			},
+		};
+		const chainInfo = {
+			height: '1173781',
+			scoreHigh: '6',
+			scoreLow: '18350901762684228126',
+			latestFinalizedBlock: {
+				finalizationEpoch: 817,
+				finalizationPoint: 8,
+				height: '1173756',
+				hash: '8B9CB1A0D275720AEA04B9CB373994F2CC3826256DECFC0DE999FE7ED42F3814',
+			},
+		};
+
+		stub(ApiNodeService, 'getNodeChainInfo').returns(Promise.resolve(chainInfo));
+		stub(ApiNodeService, 'webSocketStatus').returns(Promise.resolve(webSocketStatus));
+
+		const hangingMethods = ['getNodeInfo', 'getNodeHealth'];
+
+		hangingMethods.map((method: any) =>
+			stub(ApiNodeService, method).returns(
+				new Promise((_, reject) => {
+					setTimeout(() => {
+						reject(Error('timeout'));
+					}, 6_000);
+				}),
+			),
+		);
+		stub(ApiNodeService, 'getNodeServer').returns(Promise.resolve(serverInfo));
+
+		// Act:
+		const apiStatus = await ApiNodeService.getStatus('http://localhost:3000');
+
+		// Assert:
+		expect(apiStatus.webSocket).to.be.eql(webSocketStatus);
+		expect(apiStatus.restVersion).to.be.eq('2.4.0');
+		expect(apiStatus.chainHeight).to.be.eq('1173781');
+	}).timeout(10_000);
+});

--- a/test/Http.test.ts
+++ b/test/Http.test.ts
@@ -1,0 +1,25 @@
+import { HTTP } from '@src/services/Http';
+import { expect } from 'chai';
+import { stub } from 'sinon';
+import axios from 'axios';
+
+describe('Http', () => {
+	it('Get method timeouts after given time', async () => {
+		// Arrange:
+		stub(axios, 'get').returns(
+			new Promise((_, reject) => {
+				setTimeout(() => {
+					reject(Error('timeout'));
+				}, 5_000);
+			}),
+		);
+
+		// Act:
+		try {
+			await HTTP.get('SOME_FAKE_URL', { timeout: 2_000 });
+		} catch (err: any) {
+			// Assert:
+			expect(err.message).to.be.equal(HTTP.TIMEOUT_MSG);
+		}
+	}).timeout(3000);
+});

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,0 +1,50 @@
+import { expect } from 'chai';
+import { promiseAllTimeout, basename } from '@src/utils';
+import { Logger } from '@src/infrastructure';
+import * as winston from 'winston';
+
+describe('promiseAllTimeout', () => {
+	const logger: winston.Logger = Logger.getLogger(basename(__filename));
+
+	const timeoutPromise = (value: string, timeout: number) =>
+		new Promise((resolve, _) => {
+			setTimeout(() => resolve(value), timeout);
+		});
+	const promise = (value: string) => Promise.resolve(value);
+
+	it('no timeouts, all resolve', async () => {
+		// Arrange:
+		const promises = [timeoutPromise('promise 1', 1_000), promise('promise 2')];
+
+		// Act:
+		const [result1, result2] = await promiseAllTimeout(promises, 2_000, logger, 'test', 'timeout');
+
+		// Assert:
+		expect(result1).to.be.equal('promise 1');
+		expect(result2).to.be.equal('promise 2');
+	}).timeout(3000);
+
+	it('one of the promises timeouts after given time', async () => {
+		// Arrange:
+		const promises = [timeoutPromise('promise 1', 2_000), promise('promise 2')];
+
+		// Act:
+		const [result1, result2] = await promiseAllTimeout(promises, 1_000, logger, 'test', 'timeout');
+
+		// Assert:
+		expect(result1).to.be.equal('timeout');
+		expect(result2).to.be.equal('promise 2');
+	}).timeout(3000);
+
+	it('all timeout after given time', async () => {
+		// Arrange:
+		const promises = [timeoutPromise('promise 1', 2_000), timeoutPromise('promise 2', 2_000)];
+
+		// Act:
+		const [result1, result2] = await promiseAllTimeout(promises, 1_000, logger, 'test', 'timeout');
+
+		// Assert:
+		expect(result1).to.be.equal('timeout');
+		expect(result2).to.be.equal('timeout');
+	}).timeout(3000);
+});


### PR DESCRIPTION
### What was the issue?
After some time of running (like a month), Node Monitoring (recurring) task starts to hang at a point. We have to restart the container on such occasions which is far from _ideal_.

### What's the fix?
After digging through the logs, found out that the last log regarding the `NodeMonitor`task is one of the promises awaiting in the Promise.all [line](https://github.com/symbol/statistics-service/blob/259afa7ebda5ff5f8cc2d77f75f71b2ca688ef34/src/services/ApiNodeService.ts#L101) Since this is based on what we saw in the logs, this might not be the root cause.

The fix is basically adding a timeout logic(`promiseAllTimeout`) for the part that is waiting for all of the promises to resolve or reject. Added multiple unit tests.
