### PR TITLE
[statistics-service] task: update changelog for v1.1.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@ All notable changes to this project will be documented in this file.
 
 The changelog format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [v1.1.8][v1.1.8] - 07-Jun-2022
+
+Package  | Version | Link
+---|---------|---
+REST Core| v2.4.0  | [catapult-rest][catapult-rest@v2.4.0]
+SDK Core| v2.0.0  | [symbol-sdk][symbol-sdk@v2.0.0]
+
+- Fixed WebSocket connection leak issue [#158](https://github.com/symbol/statistics-service/pull/158)
+
 ## [v1.1.7][v1.1.7] - 12-May-2022
 
 Package  | Version | Link
@@ -184,6 +193,7 @@ REST Core| v2.1.0 | [catapult-rest](https://github.com/symbol/catapult-rest/rele
 ### Fixes
 - Cors error. [#13](https://github.com/symbol/statistics-service/issues/13)
 
+[v1.1.8]: https://github.com/symbol/statistics-service/releases/tag/v1.1.8
 [v1.1.7]: https://github.com/symbol/statistics-service/releases/tag/v1.1.7
 [v1.1.6]: https://github.com/symbol/statistics-service/releases/tag/v1.1.6
 [v1.1.5]: https://github.com/symbol/statistics-service/releases/tag/v1.1.5


### PR DESCRIPTION
Update changelog for v1.1.8 release

## [v1.1.8][v1.1.8] - 07-Jun-2022

Package  | Version | Link
---|---------|---
REST Core| v2.4.0  | [catapult-rest][catapult-rest@v2.4.0]
SDK Core| v2.0.0  | [symbol-sdk][symbol-sdk@v2.0.0]

- Fixed WebSocket connection leak issue [#158](https://github.com/symbol/statistics-service/pull/158)