### PR TITLE
[statistics-service] feat: openapi docs is now accessible via root pa…

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -29,7 +29,10 @@ class App {
 		app.use(express.json());
 		app.use(express.urlencoded({ extended: false }));
 		app.use(cors());
-		app.use('/openapi', express.static('openapi'));
+		const openapiHandler = express.static('openapi');
+
+		app.use('/', openapiHandler);
+		app.use('/openapi', openapiHandler);
 
 		/**
 		 * -------------- Start services --------------


### PR DESCRIPTION
## What was the issue?
 - openapi docs URI was easy to forget https://symbol.services/openapi
 - https://symbol.services/ was returning `404`

## What's the fix?
- openapi docs is now accessible via root path as well as /openapi
-  https://symbol.services/ and https://symbol.services/openapi are both pointing the openapi docs