### PR TITLE
fix/dockerfile node options env

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,8 @@ WORKDIR /app
 
 COPY . .
 
+ENV NODE_OPTIONS="--dns-result-order=ipv4first"
+
 RUN npm install pm2 -g && npm install && npm run build
 
 EXPOSE 4001


### PR DESCRIPTION
## What was the issue?
Jenkins build was failing due to Node 18 default dns resolution changed to ipv6.

## What's the fix?
Added an env param to the dockerfile for the node options to force ipv4 resolution first.