### PR TITLE
[statistics-service] fix: geo info unable insert

### DIFF
--- a/src/models/Node.ts
+++ b/src/models/Node.ts
@@ -177,11 +177,9 @@ const NodeSchema: Schema = new Schema({
 			},
 			district: {
 				type: String,
-				required: true,
 			},
 			zip: {
 				type: String,
-				required: true,
 			},
 		},
 	},


### PR DESCRIPTION
problem: due to the upgraded Mongoose version, the scheme `required: true` can't accept empty strings, which causes a failed insert to the database.

solution: `district` and `zip` value possible to be the empty string, remove `required: true` in this properties