### PR TITLE
[statistics-service] fix: update latest node info in list.

### DIFF
--- a/src/models/Node.ts
+++ b/src/models/Node.ts
@@ -27,7 +27,6 @@ const NodeSchema: Schema = new Schema({
 	},
 	host: {
 		type: String,
-		required: true,
 	},
 	networkGenerationHashSeed: {
 		type: String,

--- a/src/models/Node.ts
+++ b/src/models/Node.ts
@@ -27,6 +27,7 @@ const NodeSchema: Schema = new Schema({
 	},
 	host: {
 		type: String,
+		required: true,
 	},
 	networkGenerationHashSeed: {
 		type: String,

--- a/src/services/ApiNodeService.ts
+++ b/src/services/ApiNodeService.ts
@@ -35,6 +35,7 @@ export interface ApiStatus {
 	nodeStatus?: NodeStatus;
 	chainHeight?: number;
 	finalization?: FinalizedBlock;
+	nodeInfo?: NodeInfo;
 	nodePublicKey?: string;
 	restVersion?: string;
 	lastStatusCheck: number;
@@ -109,8 +110,11 @@ export class ApiNodeService {
 			);
 
 			if (nodeInfo) {
+				const { nodePublicKey, ...info } = nodeInfo;
+
 				Object.assign(apiStatus, {
-					nodePublicKey: nodeInfo.nodePublicKey,
+					nodeInfo: info,
+					nodePublicKey: nodePublicKey,
 				});
 			}
 

--- a/src/services/NodeMonitor.ts
+++ b/src/services/NodeMonitor.ts
@@ -206,6 +206,7 @@ export class NodeMonitor {
 				nodeWithInfo = {
 					...nodeWithInfo,
 					...nodeInfo,
+					host: nodeInfo?.host || nodeWithInfo.host,
 					apiStatus: status,
 				};
 			}

--- a/src/services/NodeMonitor.ts
+++ b/src/services/NodeMonitor.ts
@@ -307,8 +307,7 @@ export class NodeMonitor {
 			) {
 				return;
 			}
-
-			const nodeInx = this.nodeList.findIndex((addedNode) => addedNode.publicKey === node.publicKey || addedNode.host === node.host);
+			const nodeInx = this.nodeList.findIndex((addedNode) => addedNode.publicKey === node.publicKey);
 
 			if (nodeInx > -1) {
 				// already in the list then update and keep the last available time

--- a/src/services/NodeMonitor.ts
+++ b/src/services/NodeMonitor.ts
@@ -306,7 +306,8 @@ export class NodeMonitor {
 			) {
 				return;
 			}
-			const nodeInx = this.nodeList.findIndex((addedNode) => addedNode.publicKey === node.publicKey);
+
+			const nodeInx = this.nodeList.findIndex((addedNode) => addedNode.publicKey === node.publicKey || addedNode.host === node.host);
 
 			if (nodeInx > -1) {
 				// already in the list then update and keep the last available time

--- a/src/services/NodeMonitor.ts
+++ b/src/services/NodeMonitor.ts
@@ -200,7 +200,15 @@ export class NodeMonitor {
 			const hostUrl = await ApiNodeService.buildHostUrl(nodeHost);
 			const apiStatus = await ApiNodeService.getStatus(hostUrl);
 
-			if (apiStatus.isAvailable) nodeWithInfo.apiStatus = apiStatus;
+			if (apiStatus.isAvailable) {
+				const { nodeInfo, ...status } = apiStatus;
+
+				nodeWithInfo = {
+					...nodeWithInfo,
+					...nodeInfo,
+					apiStatus: status,
+				};
+			}
 
 			return nodeWithInfo;
 		} catch (e: any) {

--- a/test/ApiNodeService.test.ts
+++ b/test/ApiNodeService.test.ts
@@ -69,6 +69,8 @@ describe('ApiNodeService', () => {
 		const apiStatus = await ApiNodeService.getStatus(hostURL);
 
 		// Assert:
+		const { nodePublicKey, ...info } = nodeInfo;
+
 		expect(apiStatus.webSocket).to.be.deep.equal(webSocketStatus);
 		expect(apiStatus.restGatewayUrl).to.be.equal(hostURL);
 		expect(apiStatus.isAvailable).to.be.equal(true);
@@ -76,7 +78,8 @@ describe('ApiNodeService', () => {
 		expect(apiStatus.nodeStatus).to.be.deep.equal(nodeStatus);
 		expect(apiStatus.chainHeight).to.equal(chainInfo.height);
 		expect(apiStatus.finalization).to.be.deep.equal(finalization);
-		expect(apiStatus.nodePublicKey).to.be.equal(nodeInfo.nodePublicKey);
+		expect(apiStatus.nodePublicKey).to.be.equal(nodePublicKey);
+		expect(apiStatus.nodeInfo).to.be.deep.equal(info);
 		expect(apiStatus.restVersion).to.be.equal(serverInfo.restVersion);
 		expect(apiStatus.lastStatusCheck).to.be.not.undefined;
 	});
@@ -116,14 +119,14 @@ describe('ApiNodeService', () => {
 	it('closes websocket connection after checking websocket health', async () => {
 		// Arrange:
 		const close = stub();
-		const clientWsMock = ({
+		const clientWsMock = {
 			on: (event: string, callback: any) => {
 				if (event === 'open' || event === 'error') {
 					callback();
 				}
 			},
 			close,
-		} as unknown) as WebSocket;
+		} as unknown as WebSocket;
 
 		stub(ApiNodeService, 'createWebSocketClient').returns(clientWsMock);
 

--- a/test/NodeMonitor.test.ts
+++ b/test/NodeMonitor.test.ts
@@ -6,11 +6,10 @@ import { expect } from 'chai';
 import { stub, restore, useFakeTimers } from 'sinon';
 
 describe('NodeMonitor', () => {
-	let clock: sinon.SinonFakeTimers;
-	const mockFixedDate = new Date('2024-01-14T12:00:00Z');
-
 	describe('removeUnavailableNodesAndUpdateLastAvailable', () => {
+		let clock: sinon.SinonFakeTimers;
 		let nodeMonitor: NodeMonitor;
+		const mockFixedDate = new Date('2024-01-14T12:00:00Z');
 
 		const createNode = (hostname: string, roles: number, apiAvailable?: any, peerAvailable?: any) =>
 			({
@@ -119,81 +118,6 @@ describe('NodeMonitor', () => {
 		it('should handle empty node list', () => {
 			const result = (nodeMonitor as any).removeUnavailableNodesAndUpdateLastAvailable([]);
 			expect(result).to.deep.equal([]);
-		});
-	});
-
-	describe('addNodesToList', () => {
-		let nodeMonitor: NodeMonitor;
-
-		beforeEach(() => {
-			clock = useFakeTimers(mockFixedDate);
-			nodeMonitor = new NodeMonitor(0);
-			stub(nodeMonitor, 'generationHashSeed' as any).value('1234');
-			stub(nodeMonitor, 'networkIdentifier' as any).value(1);
-		});
-
-		afterEach(() => {
-			clock.restore();
-		});
-
-		const createNode = (hostname: string, publicKey: string) =>
-			({
-				hostname,
-				roles: 3,
-				networkGenerationHashSeed: '1234',
-				networkIdentifier: 1,
-				port: 3000,
-				publicKey,
-				nodePublicKey: 'node public',
-				version: 1,
-				hostDetail: {
-					host: 'abc.com',
-					coordinates: {
-						latitude: 51.1878,
-						longitude: 6.8607,
-					},
-					location: 'Düsseldorf, NW, Germany',
-					ip: '127.0.1.10',
-					organization: 'ABC Provider',
-					as: 'ABC Provider',
-					country: 'Germany',
-					region: 'NW',
-					city: 'Düsseldorf',
-				},
-			} as any);
-
-		it('should filter nodes with the duplicated hostname', () => {
-			// Arrange:
-			const nodes = [createNode('abc.com', 'publicKey1'), createNode('abc.com', 'publicKey2'), createNode('abc.com', 'publicKey3')];
-
-			// Act:
-			(nodeMonitor as any).addNodesToList(nodes);
-
-			// Assert:
-			expect((nodeMonitor as any).nodeList).to.have.lengthOf(1);
-			expect((nodeMonitor as any).nodeList).to.deep.equal([
-				{
-					...nodes[2],
-					lastAvailable: mockFixedDate,
-				},
-			]);
-		});
-
-		it('should filter nodes with the duplicated publicKey', () => {
-			// Arrange:
-			const nodes = [createNode('abc.com', 'publicKey1'), createNode('xyz.com', 'publicKey1')];
-
-			// Act:
-			(nodeMonitor as any).addNodesToList(nodes);
-
-			// Assert:
-			expect((nodeMonitor as any).nodeList).to.have.lengthOf(1);
-			expect((nodeMonitor as any).nodeList).to.deep.equal([
-				{
-					...nodes[1],
-					lastAvailable: mockFixedDate,
-				},
-			]);
 		});
 	});
 

--- a/test/NodeMonitor.test.ts
+++ b/test/NodeMonitor.test.ts
@@ -155,6 +155,7 @@ describe('NodeMonitor', () => {
 			lastStatusCheck: 1000,
 		};
 		const mockLightApiStatus = {
+			nodeInfo: mockNodeInfo,
 			restGatewayUrl: 'https://abc.com:3001',
 			isAvailable: true,
 			isHttpsEnabled: true,
@@ -253,29 +254,44 @@ describe('NodeMonitor', () => {
 			const result = await (nodeMonitor as any).getNodeInfo(mockNodeInfo);
 
 			// Assert:
+			const { nodeInfo, ...expectedApiStatus } = mockLightApiStatus;
 			expect(result).to.be.deep.equal({
 				...mockNodeInfo,
 				hostDetail: mockGeoInfo,
 				peerStatus: mockPeerStatus,
-				apiStatus: mockLightApiStatus,
+				apiStatus: expectedApiStatus,
 			});
 		});
 
-		it('returns api node info', async () => {
+		const assertApiNodeInfo = async (existingNodeInfo: any) => {
 			// Arrange:
 			stubHostDetailCached.returns(Promise.resolve(mockGeoInfo));
 			stubPeerStatus.returns(Promise.resolve(mockPeerStatus));
 			stubApiStatus.returns(Promise.resolve(mockFullApiStatus) as any);
 
 			// Act:
-			const result = await (nodeMonitor as any).getNodeInfo(mockNodeInfo);
+			const result = await (nodeMonitor as any).getNodeInfo(existingNodeInfo);
 
 			// Assert:
+			const { nodeInfo, ...expectedApiStatus } = mockFullApiStatus;
 			expect(result).to.be.deep.equal({
 				...mockNodeInfo,
 				hostDetail: mockGeoInfo,
 				peerStatus: mockPeerStatus,
-				apiStatus: mockFullApiStatus,
+				apiStatus: expectedApiStatus,
+			});
+		};
+
+		it('returns api node info', async () => {
+			assertApiNodeInfo(mockNodeInfo);
+		});
+
+		it('returns overwriting node info with latest node info', async () => {
+			assertApiNodeInfo({
+				...mockNodeInfo,
+				friendlyName: 'no-name',
+				host: '',
+				version: 0,
 			});
 		});
 	});

--- a/test/NodeMonitor.test.ts
+++ b/test/NodeMonitor.test.ts
@@ -339,19 +339,19 @@ describe('NodeMonitor', () => {
 			});
 		});
 
-		const assertApiNodeInfo = async (existingNodeInfo: any) => {
+		const assertApiNodeInfo = async (existingNodeInfo: any, latestNodeInfo: any, expectedResult: any) => {
 			// Arrange:
 			stubHostDetailCached.returns(Promise.resolve(mockGeoInfo));
 			stubPeerStatus.returns(Promise.resolve(mockPeerStatus));
-			stubApiStatus.returns(Promise.resolve(mockFullApiStatus) as any);
+			stubApiStatus.returns(Promise.resolve(latestNodeInfo) as any);
 
 			// Act:
 			const result = await (nodeMonitor as any).getNodeInfo(existingNodeInfo);
 
 			// Assert:
-			const { nodeInfo, ...expectedApiStatus } = mockFullApiStatus;
+			const { nodeInfo, ...expectedApiStatus } = latestNodeInfo;
 			expect(result).to.be.deep.equal({
-				...mockNodeInfo,
+				...expectedResult,
 				hostDetail: mockGeoInfo,
 				peerStatus: mockPeerStatus,
 				apiStatus: expectedApiStatus,
@@ -359,16 +359,40 @@ describe('NodeMonitor', () => {
 		};
 
 		it('returns api node info', async () => {
-			assertApiNodeInfo(mockNodeInfo);
+			assertApiNodeInfo(mockNodeInfo, mockFullApiStatus, mockNodeInfo);
 		});
 
 		it('returns overwriting node info with latest node info', async () => {
-			assertApiNodeInfo({
-				...mockNodeInfo,
-				friendlyName: 'no-name',
-				host: '',
-				version: 0,
-			});
+			assertApiNodeInfo(
+				{
+					...mockNodeInfo,
+					friendlyName: 'no-name',
+					host: '',
+					version: 0,
+				},
+				mockFullApiStatus,
+				mockNodeInfo,
+			);
+		});
+
+		it('Remain host name if latest node info host is empty', async () => {
+			assertApiNodeInfo(
+				{
+					...mockNodeInfo,
+					host: '10.10.10.10',
+				},
+				{
+					...mockFullApiStatus,
+					nodeInfo: {
+						...mockNodeInfo,
+						host: '',
+					},
+				},
+				{
+					...mockNodeInfo,
+					host: '10.10.10.10',
+				},
+			);
 		});
 	});
 });


### PR DESCRIPTION
Problem: Some node versions have not been updated on the list.
Solution: 
- Update database node schema, the hostname can be the empty string.
- Query the latest node info, and update in node list.
- Added validation check in the peer list, to prevent duplicated hostname.