### PR TITLE
[statistics-service] fix: filters duplicate node by host name.

### DIFF
--- a/src/models/Node.ts
+++ b/src/models/Node.ts
@@ -28,6 +28,7 @@ const NodeSchema: Schema = new Schema({
 	host: {
 		type: String,
 		required: true,
+		unique: true,
 	},
 	networkGenerationHashSeed: {
 		type: String,
@@ -115,7 +116,6 @@ const NodeSchema: Schema = new Schema({
 	publicKey: {
 		type: String,
 		required: true,
-		unique: true,
 		index: true,
 	},
 	roles: {

--- a/src/services/NodeMonitor.ts
+++ b/src/services/NodeMonitor.ts
@@ -307,7 +307,7 @@ export class NodeMonitor {
 			) {
 				return;
 			}
-			const nodeInx = this.nodeList.findIndex((addedNode) => addedNode.publicKey === node.publicKey);
+			const nodeInx = this.nodeList.findIndex((addedNode) => addedNode.host === node.host);
 
 			if (nodeInx > -1) {
 				// already in the list then update and keep the last available time
@@ -324,6 +324,8 @@ export class NodeMonitor {
 				}
 				this.nodeList.push(node);
 			}
+
+			console.log('after nodeList :>> ', this.nodeList);
 		});
 	};
 

--- a/test/NodeMonitor.test.ts
+++ b/test/NodeMonitor.test.ts
@@ -6,10 +6,11 @@ import { expect } from 'chai';
 import { stub, restore, useFakeTimers } from 'sinon';
 
 describe('NodeMonitor', () => {
+	let clock: sinon.SinonFakeTimers;
+	const mockFixedDate = new Date('2024-01-14T12:00:00Z');
+
 	describe('removeUnavailableNodesAndUpdateLastAvailable', () => {
-		let clock: sinon.SinonFakeTimers;
 		let nodeMonitor: NodeMonitor;
-		const mockFixedDate = new Date('2024-01-14T12:00:00Z');
 
 		const createNode = (hostname: string, roles: number, apiAvailable?: any, peerAvailable?: any) =>
 			({
@@ -317,6 +318,64 @@ describe('NodeMonitor', () => {
 					host: '10.10.10.10',
 				},
 			);
+		});
+	});
+
+	describe('addNodesToList', () => {
+		let nodeMonitor: NodeMonitor;
+
+		beforeEach(() => {
+			clock = useFakeTimers(mockFixedDate);
+			nodeMonitor = new NodeMonitor(0);
+			stub(nodeMonitor, 'generationHashSeed' as any).value('1234');
+			stub(nodeMonitor, 'networkIdentifier' as any).value(1);
+		});
+
+		afterEach(() => {
+			clock.restore();
+		});
+
+		const createNode = (host: string, publicKey: string) =>
+			({
+				host,
+				roles: 3,
+				networkGenerationHashSeed: '1234',
+				networkIdentifier: 1,
+				port: 3000,
+				publicKey,
+				nodePublicKey: 'node public',
+				version: 1,
+				hostDetail: {
+					host: 'abc.com',
+					coordinates: {
+						latitude: 51.1878,
+						longitude: 6.8607,
+					},
+					location: 'Düsseldorf, NW, Germany',
+					ip: '127.0.1.10',
+					organization: 'ABC Provider',
+					as: 'ABC Provider',
+					country: 'Germany',
+					region: 'NW',
+					city: 'Düsseldorf',
+				},
+			} as any);
+
+		it('should filter nodes with the duplicated hostname', () => {
+			// Arrange:
+			const nodes = [createNode('abc.com', 'publicKey1'), createNode('abc.com', 'publicKey2')];
+
+			// Act:
+			(nodeMonitor as any).addNodesToList(nodes);
+
+			// Assert:
+			expect((nodeMonitor as any).nodeList).to.have.lengthOf(1);
+			expect((nodeMonitor as any).nodeList).to.deep.equal([
+				{
+					...nodes[1],
+					lastAvailable: mockFixedDate,
+				},
+			]);
 		});
 	});
 });


### PR DESCRIPTION
Problem: When inserted into a database, the duplicate node list causes the error.
Solution: filter duplicate nodes by host name instead of the public key.