### PR TITLE
[statistics-service] fix: prevent duplicated data insert to db.

### DIFF
--- a/src/services/NodeMonitor.ts
+++ b/src/services/NodeMonitor.ts
@@ -324,13 +324,18 @@ export class NodeMonitor {
 				}
 				this.nodeList.push(node);
 			}
-
-			console.log('after nodeList :>> ', this.nodeList);
 		});
 	};
 
 	private addNodesToNodeInfoList = (nodes: INode[]) => {
-		this.nodeInfoList = this.nodeInfoList.concat(nodes);
+		const existingNodeHosts = new Set(this.nodeInfoList.map((node) => node.host));
+
+		nodes.forEach((node) => {
+			if (!existingNodeHosts.has(node.host)) {
+				this.nodeInfoList.push(node);
+				existingNodeHosts.add(node.host);
+			}
+		});
 	};
 
 	private isNodeBelongToNetwork = (node: INode): boolean => {

--- a/test/NodeMonitor.test.ts
+++ b/test/NodeMonitor.test.ts
@@ -378,4 +378,45 @@ describe('NodeMonitor', () => {
 			]);
 		});
 	});
+
+	describe('addNodesToNodeInfoList', () => {
+		const nodes = [
+			{
+				host: 'abc.com',
+				roles: 3,
+				networkGenerationHashSeed: '1234',
+				networkIdentifier: 1,
+				port: 3000,
+				publicKey: 'publicKey1',
+				nodePublicKey: 'node public',
+				version: 1,
+				hostDetail: {},
+			},
+		];
+
+		it('should add nodes to node info list', async () => {
+			// Arrange:
+			const nodeMonitor = new NodeMonitor(0);
+
+			// Act:
+			await (nodeMonitor as any).addNodesToNodeInfoList(nodes);
+
+			// Assert:
+			expect((nodeMonitor as any).nodeInfoList).to.have.lengthOf(1);
+		});
+
+		it('should filter nodes with the duplicated hostname', async () => {
+			// Arrange:
+			const nodeMonitor = new NodeMonitor(0);
+
+			// pre insert nodes
+			await (nodeMonitor as any).addNodesToNodeInfoList(nodes);
+
+			// Act:
+			await (nodeMonitor as any).addNodesToNodeInfoList(nodes);
+
+			// Assert:
+			expect((nodeMonitor as any).nodeInfoList).to.have.lengthOf(1);
+		});
+	});
 });


### PR DESCRIPTION
Problem: Duplicated node info caused the node insertion to fail in the database
Solution: Create a node `Map()` to ensure no duplicate data in the list