### PR TITLE
[statistics-service] fix: update schema to handle empty string

### DIFF
--- a/src/models/Node.ts
+++ b/src/models/Node.ts
@@ -154,26 +154,21 @@ const NodeSchema: Schema = new Schema({
 			},
 			organization: {
 				type: String,
-				required: true,
 			},
 			as: {
 				type: String,
-				required: true,
 			},
 			continent: {
 				type: String,
 			},
 			country: {
 				type: String,
-				required: true,
 			},
 			region: {
 				type: String,
-				required: true,
 			},
 			city: {
 				type: String,
-				required: true,
 			},
 			district: {
 				type: String,


### PR DESCRIPTION
Problem: Some information is returned as an empty string in the geo information.
Solution: removed `required` in string field.